### PR TITLE
fix: remove faulty thousand separator for negative numbers

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -33,11 +33,13 @@ export function format (locale, value, options) {
     fraction = fraction.slice(2);
   }
 
+  // Don't count the negative sign as a digit when adding the thousand separator sign
+  const decimalIndexStart = decimal[0] === '-' ? 1 : 0;
   for (let i = decimal.length - 1; i >= 0; i--) {
     res = decimal[i] + res;
     thousandIterator++;
 
-    if (thousandIterator === 3 && i-1 >= 0) {
+    if (thousandIterator === 3 && i - 1 >= decimalIndexStart) {
       res = thousandSeparator + res;
       thousandIterator = 0;
     }

--- a/tests/test.currency.js
+++ b/tests/test.currency.js
@@ -188,6 +188,18 @@ describe('currency', () => {
       should(sanitizeSpaces(kittenFormat.formatC(200, _options))).eql('200,00 €');
     });
 
+    it("should correctly format the thousand separator", () => {
+      var _options = {
+        locale : 'en-GB',
+      };
+      should(sanitizeSpaces(kittenFormat.formatC(200, _options))).eql('£200.00');
+      should(sanitizeSpaces(kittenFormat.formatC(20000, _options))).eql('£20,000.00');
+      should(sanitizeSpaces(kittenFormat.formatC(2000000, _options))).eql('£2,000,000.00');
+      should(sanitizeSpaces(kittenFormat.formatC(-200, _options))).eql('£-200.00');
+      should(sanitizeSpaces(kittenFormat.formatC(-20000, _options))).eql('£-20,000.00');
+      should(sanitizeSpaces(kittenFormat.formatC(-2000000, _options))).eql('£-2,000,000.00');
+    });
+
     it('should be fast', () => {
       var _locales        = ['fr-FR', 'fr-CHF', 'en-GB'];
       var _executionTimes = [];

--- a/tests/test.number.js
+++ b/tests/test.number.js
@@ -181,6 +181,18 @@ describe('number', () => {
       should(sanitizeSpaces(kittenFormat.formatN(20000.99, _options))).eql('20,000.99');
     });
 
+    it("should correctly format the thousand separator", () => {
+      var _options = {
+        locale : 'en-GB',
+      };
+      should(sanitizeSpaces(kittenFormat.formatN(200, _options))).eql('200');
+      should(sanitizeSpaces(kittenFormat.formatN(20000, _options))).eql('20,000');
+      should(sanitizeSpaces(kittenFormat.formatN(2000000, _options))).eql('2,000,000');
+      should(sanitizeSpaces(kittenFormat.formatN(-200, _options))).eql('-200');
+      should(sanitizeSpaces(kittenFormat.formatN(-20000, _options))).eql('-20,000');
+      should(sanitizeSpaces(kittenFormat.formatN(-2000000, _options))).eql('-2,000,000');
+    });
+
     it('should be fast', () => {
       var _locales        = ['fr-FR', 'fr-CHF', 'en-GB'];
       var _executionTimes = [];


### PR DESCRIPTION
Fix a formatting bug where a thousand separator would be added to negative numbers superior to -1000 in `formatCurrency` and `formatNumber`.

Example:

```js
kittenFormat.formatCurrency(-120, { precision : 2, minimumFractionDigits : 2 })  
"€-,120.00"  

kittenFormat.formatNumber(-120, { precision : 2, minimumFractionDigits : 2 })  
"-,120.00"

kittenFormat.formatNumber(-120)
"-,120" 
```