### PR TITLE
fix: use lowercase locale name for exported locales

### DIFF
--- a/build-locales.js
+++ b/build-locales.js
@@ -79,7 +79,7 @@ async function build(input, outputFile, locale) {
   const outputOptions = {
     file    : outputFile,
     format  : 'umd',
-    name    : 'kittenFormat_' + locale,
+    name    : 'kittenFormat_' + locale.toLowerCase(),
     globals : {
       'kitten-format' : 'kittenFormat'
     }

--- a/locales/es-CL.js
+++ b/locales/es-CL.js
@@ -17,8 +17,8 @@ var locale = {
     '-6' : 'μ',
     '-9' : 'n'
   },
-  thousandSeparator : ',',
-  decimalSeparator  : '.',
+  thousandSeparator : ' ',
+  decimalSeparator  : ',',
   isCurrencyFirst   : true
 };
 


### PR DESCRIPTION
Easilys ne chargeait pas les locales correctement, utilisant les minuscules

et fix du séparateurs de décimales espagnol chili

https://git.ideolys.com/ideolys/easilys/-/issues/16526